### PR TITLE
修复: 点击左边菜单如果当前tab存在则没响应的问题

### DIFF
--- a/src/main/webapp/WEB-INF/admin/index.jsp
+++ b/src/main/webapp/WEB-INF/admin/index.jsp
@@ -45,6 +45,9 @@
           //注：使用iframe即可防止同一个页面出现js和css冲突的问题
           content : '<iframe name="'+name+'"id="'+tabId+'"src="'+url+'" width="100%" height="100%" frameborder="0" scrolling="auto">'+'</iframe>'
         });
+      }else{
+        //如果当前tab存在则激活原来的tab
+        $("#centerTab").tabs('select',title);
       }
     }
 


### PR DESCRIPTION
目前点击左边菜单如果tab已存在则无反应
修改为如果tab已存在则激活对应的tab
chrome和ie测试通过