### PR TITLE
修复:连接池增加取出校验,解决mysql默认8小时断开问题

### DIFF
--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -44,7 +44,10 @@
 		<property name="removeAbandoned" value="true"/>
 		<property name="removeAbandonedTimeout" value="180" />
 		<property name="logAbandoned" value="true"/>
- 	</bean>
+		<property name="testOnBorrow" value="true"/>
+		<property name="testWhileIdle" value="true"/>
+		<property name="validationQuery" value="select 1"/>
+	</bean>
 
 	<!-- Hibernate配置 -->
 	<bean id="sessionFactory" class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">


### PR DESCRIPTION
从连接池取出连接时对连接进行校验
解决mysql默认8小时无访问连接被断开导致连接不可用的问题